### PR TITLE
Dashboard fixes

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -37322,6 +37322,9 @@ function createChart() {
             labelString: 'temperatuur in °C'
           }
         }]
+      },
+      legend: {
+        position: 'right'
       }
     }
   });

--- a/resources/js/dashboard.js
+++ b/resources/js/dashboard.js
@@ -34,6 +34,9 @@ function createChart() {
                         labelString: 'temperatuur in °C'
                     }
                 }]
+            },
+            legend: {
+                position: 'right'
             }
         }
     });

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -7,14 +7,22 @@
     <title>Data Visualisation Test</title>
 </head>
 <body>
-     <!--TODO FIX ID FOR EVERY STATION-->
 <div class="brand">PET waardes van de afgelopen 7 dagen</div>
 <div class="container">
     <div class="row">
-            <div class="box col-12">
-            <canvas id="chart"></canvas>
-            </div>
+        <div class="box col-12">
+            <canvas class="mb-3" id="chart"></canvas>
+            <h3 class="text-center">De kleuren van de lijnen komt overeen met de stad waar het station te vinden is:</h3>
+            <ul>
+                <li>Vlissingen: <span style="color:blue">blauw</span></li>
+                <li>Middelburg: <span style="color:red">rood</span></li>
+                <li>Rotterdam: <span style="color:orange">oranje</span></li>
+                <li>Leeuwaarden: <span style="color:green">groen</span></li>
+                <li>Groningen: <span style="color:purple">paars</span></li>
+            </ul>
+        </div>
     </div>
+</div>
 <footer>
     <div class="container">
         <div class="row">


### PR DESCRIPTION
## Changes
- Fixed title typo.
- Changed axes to have a title.
- X axis now displays time in MMM D H:mm format.
- Legend labels now use the station name.
- Legend is now oriented right of the graph.
- Line colours are now organised by city.

## Additions
- Added missing station HHG1, Paddepoel, Groningen.